### PR TITLE
Explicitly build Release packages for NuGet

### DIFF
--- a/.github/workflows/publish-nuget-packages.yaml
+++ b/.github/workflows/publish-nuget-packages.yaml
@@ -35,7 +35,7 @@ jobs:
         run: dotnet --info
 
       - name: Pack
-        run: dotnet pack -p:Version="${{ inputs.version }}" -p:RepositoryBranch=${{ github.ref_name }} -p:RepositoryCommit="${{ github.sha }}"
+        run: dotnet pack -c Release -p:Version="${{ inputs.version }}" -p:RepositoryBranch=${{ github.ref_name }} -p:RepositoryCommit="${{ github.sha }}"
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
## Summary

This PR explicitly specifies build configuration when creating NuGet packages with `dotnet pack`. 
We want to make sure released NuGet packages are built in the `Release` configuration, instead of falling back to the default (usually `Debug`).

## Changes

- Modified the build script to specify the `Release` configuration while running `dotnet pack`.

## Explanation

Currently, our CI/CD pipeline uses `dotnet pack` to create NuGet packages. However, we do not specify a build configuration when running this command. As a result, the projects get built in their default configuration. 

This means that unless overwritten at `.csproj` level, the projects will be built in `Debug` configuration.