### PR TITLE
Changed: Use MkDocs Directly rather than Via Docker Container based Action (fixes #14)

### DIFF
--- a/.github/workflows/mkdocs-build-and-deploy.yaml
+++ b/.github/workflows/mkdocs-build-and-deploy.yaml
@@ -30,19 +30,28 @@ jobs:
         with:
           submodules: "recursive"
 
-      - name: Setup Pages
-        id: pages
-        uses: actions/configure-pages@v3
-
-      - name: Build
-        uses: Tiryoh/actions-mkdocs@v0.23.0
+      - name: Setup Python
+        uses: actions/setup-python@v5
         with:
-          mkdocs_version: ${{ inputs.mkdocs-version }}
-          requirements: ${{ inputs.requirements-file }}
-          configfile: ${{ inputs.config-file }}
+          python-version: 3.x
+
+      - name: Install MkDocs and Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ "${{ inputs.mkdocs-version }}" = "latest" ]; then
+            pip install mkdocs-material
+          else
+            pip install mkdocs-material==${{ inputs.mkdocs-version }}
+          fi
+          if [ -f ${{ inputs.requirements-file }} ]; then
+            pip install -r ${{ inputs.requirements-file }}
+          fi
+
+      - name: Build MkDocs Site
+        run: mkdocs build --config-file ${{ inputs.config-file }}
 
       - name: Upload pages artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           name: "github-pages"
           path: "./site"


### PR DESCRIPTION
Fixes the issue of being unable to override version (it failed in old workflow), and sometimes being out of date with mainline mkdocs.

The new workflow installs python and mkdocs directly, then does the deployment by building with the just installed binary. It respects existing settings, such as allowing users to specify `requirements.txt`.

We also updated the actions versions.